### PR TITLE
Untar makedirs fix

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -193,9 +193,7 @@ def main(unused_argv):
       raise ValueError("You cannot supply --train_dir if supplying "
                        "--input_model_tgz")
     # Untar.
-    if os.path.exists(FLAGS.untar_model_dir):
-      os.rmdir(FLAGS.untar_model_dir)
-    os.makedirs(FLAGS.untar_model_dir)
+    os.makedirs(FLAGS.untar_model_dir, exist_ok=True)
     tarfile.open(FLAGS.input_model_tgz).extractall(FLAGS.untar_model_dir)
     FLAGS.train_dir = FLAGS.untar_model_dir
 


### PR DESCRIPTION
Avoids unnecessary directory deletion and prevents error while making new directory if that directory already exists.

If the directory removal is important, suggest:
- adding a warning to the user first. I hadn't expected anything to get deleted by this, and had pointed to a large existing directory.
- replacing os.rmdir with shutil.rmtree. os.rmdir fails on non-empty directories.